### PR TITLE
Add mutating functionalities

### DIFF
--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -1,6 +1,7 @@
 cache:
   cleanUpIntervalSecond: 30
   entryTtlSecond: 10
+idleConnectionTimeout: 15s
 ingressClasses:
 - "private"
 - "inter-dc"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,9 +23,10 @@ import (
 var config Config
 
 type Config struct {
-	Cache          Cache    `yaml:"cache"`
-	IngressClasses []string `yaml:"ingressClasses"`
-	Webhook        Webhook  `yaml:"webhook"`
+	Cache                 Cache    `yaml:"cache"`
+	IdleConnectionTimeout string   `yaml:"idleConnectionTimeout"`
+	IngressClasses        []string `yaml:"ingressClasses"`
+	Webhook               Webhook  `yaml:"webhook"`
 }
 
 type Cache struct {

--- a/internal/webhook/mutate.go
+++ b/internal/webhook/mutate.go
@@ -1,0 +1,72 @@
+package webhook
+
+import (
+	"fmt"
+	"net/http"
+
+	jsoniter "github.com/json-iterator/go"
+	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	"github.com/snapp-incubator/contour-admission-webhook/internal/cache"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type mutator interface {
+	mutate(mr *mutateRequest)
+	setNext(mutator)
+}
+
+type mutateRequest struct {
+	newObj    *contourv1.HTTPProxy
+	mutations []map[string]interface{}
+}
+
+//nolint:varnamelen
+func mutateV1(ar admissionv1.AdmissionReview, _ *cache.Cache) (*admissionv1.AdmissionResponse, *httpErr) {
+	contourv1HttpproxyResource := metav1.GroupVersionResource{Group: "projectcontour.io", Version: "v1", Resource: "httpproxies"}
+
+	if ar.Request.Resource != contourv1HttpproxyResource {
+		return nil, &httpErr{code: http.StatusBadRequest,
+			message: fmt.Sprintf("requested resource must be %s", contourv1HttpproxyResource)}
+	}
+
+	httpproxy := &contourv1.HTTPProxy{}
+
+	if _, _, err := deserializer.Decode(ar.Request.Object.Raw, nil, httpproxy); err != nil {
+		return nil, &httpErr{code: http.StatusInternalServerError,
+			message: fmt.Sprintf("requested resource could not be deserialized: %s", err.Error())}
+	}
+
+	mr := &mutateRequest{
+		newObj:    httpproxy,
+		mutations: []map[string]interface{}{},
+	}
+
+	response := &admissionv1.AdmissionResponse{}
+	response.Allowed = true
+
+	switch ar.Request.Operation {
+	case admissionv1.Create, admissionv1.Update:
+		mict := mutateIdleConnectionTimeout{}
+
+		mict.mutate(mr)
+
+		patch, err := jsoniter.Marshal(mr.mutations)
+		if err != nil {
+			return nil, &httpErr{code: http.StatusInternalServerError,
+				message: fmt.Sprintf("error encoding patch object to json: %s", err.Error())}
+		}
+
+		patchType := admissionv1.PatchTypeJSONPatch
+		response.PatchType = &patchType
+		response.Patch = patch
+
+		return response, nil
+
+	case admissionv1.Delete:
+		return response, nil
+	}
+
+	return nil, &httpErr{code: http.StatusBadRequest,
+		message: "operation being performed on the requested resource must be one of CREATE, UPDATE or DELETE"}
+}

--- a/internal/webhook/rule_idle_connection_timeout.go
+++ b/internal/webhook/rule_idle_connection_timeout.go
@@ -22,7 +22,7 @@ func (mict mutateIdleConnectionTimeout) mutate(mr *mutateRequest) {
 					map[string]interface{}{
 						"op":    "add",
 						"path":  fmt.Sprintf("/spec/routes/%d/timeoutPolicy/idleConnection", index),
-						"value": "15s",
+						"value": idleConnectionTimeout,
 					})
 
 				mutated = true
@@ -32,7 +32,7 @@ func (mict mutateIdleConnectionTimeout) mutate(mr *mutateRequest) {
 						"op":   "add",
 						"path": fmt.Sprintf("/spec/routes/%d/timeoutPolicy", index),
 						"value": map[string]string{
-							"idleConnection": "15s",
+							"idleConnection": idleConnectionTimeout,
 						},
 					})
 

--- a/internal/webhook/rule_idle_connection_timeout.go
+++ b/internal/webhook/rule_idle_connection_timeout.go
@@ -1,0 +1,71 @@
+package webhook
+
+import "fmt"
+
+type mutateIdleConnectionTimeout struct {
+	next mutator
+}
+
+//nolint:varnamelen
+func (mict mutateIdleConnectionTimeout) mutate(mr *mutateRequest) {
+	//nolint:nestif
+	if mr.newObj.Spec.TCPProxy == nil && len(mr.newObj.Spec.Routes) > 0 {
+		var mutated bool
+
+		for index, route := range mr.newObj.Spec.Routes {
+			if route.TimeoutPolicy != nil {
+				if route.TimeoutPolicy.IdleConnection != "" {
+					continue
+				}
+
+				mr.mutations = append(mr.mutations,
+					map[string]interface{}{
+						"op":    "add",
+						"path":  fmt.Sprintf("/spec/routes/%d/timeoutPolicy/idleConnection", index),
+						"value": "15s",
+					})
+
+				mutated = true
+			} else {
+				mr.mutations = append(mr.mutations,
+					map[string]interface{}{
+						"op":   "add",
+						"path": fmt.Sprintf("/spec/routes/%d/timeoutPolicy", index),
+						"value": map[string]string{
+							"idleConnection": "15s",
+						},
+					})
+
+				mutated = true
+			}
+		}
+
+		if mutated {
+			if mr.newObj.Annotations != nil {
+				mr.mutations = append(mr.mutations,
+					map[string]interface{}{
+						"op":    "add",
+						"path":  "/metadata/annotations/policies.network.snappcloud.io~1added-timeoutPolicy-idleConnection",
+						"value": "",
+					})
+			} else {
+				mr.mutations = append(mr.mutations,
+					map[string]interface{}{
+						"op":   "add",
+						"path": "/metadata/annotations",
+						"value": map[string]string{
+							"policies.network.snappcloud.io/added-timeoutPolicy-idleConnection": "",
+						},
+					})
+			}
+		}
+	}
+
+	if mict.next != nil {
+		mict.next.mutate(mr)
+	}
+}
+
+func (mict *mutateIdleConnectionTimeout) setNext(m mutator) {
+	mict.next = m
+}

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -29,7 +29,8 @@ var (
 
 	json = jsoniter.ConfigCompatibleWithStandardLibrary
 
-	entryTtlSecond int
+	entryTtlSecond        int
+	idleConnectionTimeout string
 
 	logger = ctrl.Log.WithName("webhook")
 )
@@ -206,6 +207,7 @@ func (wh *Webhook) Setup(stopCh <-chan struct{}) (<-chan struct{}, <-chan struct
 	// Populate the global variable once to prevent further resource allocations per validation request
 	cfg := config.GetConfig()
 	entryTtlSecond = cfg.Cache.EntryTtlSecond
+	idleConnectionTimeout = cfg.IdleConnectionTimeout
 
 	serverOptions := newServerOptions(cfg.Webhook.Port, cfg.Webhook.TLSCertFile, cfg.Webhook.TLSKeyFile)
 


### PR DESCRIPTION
This PR adds mutating functionalities to the webhook and registers the first mutating rule which mutates the timeout for how long the connection from the proxy to the upstream service is kept when there are no active requests.